### PR TITLE
Allow cookie name to be overridden via config

### DIFF
--- a/lib/split/persistence/cookie_adapter.rb
+++ b/lib/split/persistence/cookie_adapter.rb
@@ -4,6 +4,7 @@ require "json"
 module Split
   module Persistence
     class CookieAdapter
+      DEFAULT_CONFIG = {cookie_key_name: "split"}.freeze
 
       def initialize(context)
         @context = context
@@ -31,7 +32,7 @@ module Split
       private
 
       def set_cookie(value = {})
-        cookie_key = :split.to_s
+        cookie_key = self.class.config[:cookie_key_name].to_s
         cookie_value = default_options.merge(value: JSON.generate(value))
         if action_dispatch?
           @context.cookies[cookie_key] = cookie_value
@@ -67,7 +68,7 @@ module Split
 
       def hash
         @hash ||= begin
-          if cookies = @cookies[:split.to_s]
+          if cookies = @cookies[self.class.config[:cookie_key_name].to_s]
             begin
               JSON.parse(cookies)
             rescue JSON::ParserError
@@ -85,6 +86,19 @@ module Split
 
       def action_dispatch?
         defined?(Rails) && @response.is_a?(ActionDispatch::Response)
+      end
+
+      def self.with_config(options={})
+        self.config.merge!(options)
+        self
+      end
+
+      def self.config
+        @config ||= DEFAULT_CONFIG.dup
+      end
+
+      def self.reset_config!
+        @config = DEFAULT_CONFIG.dup
       end
     end
   end

--- a/spec/persistence/cookie_adapter_spec.rb
+++ b/spec/persistence/cookie_adapter_spec.rb
@@ -17,6 +17,16 @@ describe Split::Persistence::CookieAdapter do
     end
   end
 
+  describe ".config" do
+    context 'config with overridden cookie key name' do
+      before { Split::Persistence::CookieAdapter.with_config(:cookie_key_name => 'foo123') }
+
+      it 'should be "foo123"' do
+        expect(Split::Persistence::CookieAdapter.config[:cookie_key_name]).to eq('foo123')
+      end
+    end
+  end
+
   describe "#delete" do
     it "should delete the given key" do
       subject["my_key"] = "my_value"


### PR DESCRIPTION
```ruby
Split.configure do |config|
  config.persistence = Split::Persistence::CookieAdapter.with_config(
    cookie_key_name: "foo"
  )
end
```