### PR TITLE
Use HMSET to set multiple keys at one go

### DIFF
--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -87,8 +87,9 @@ module Split
         persist_experiment_configuration
       end
 
-      redis.hset(experiment_config_key, :resettable, resettable,
-                                        :algorithm, algorithm.to_s)
+      redis.hmset(experiment_config_key, :resettable, resettable,
+                                         :algorithm, algorithm.to_s)
+
       self
     end
 


### PR DESCRIPTION
We use the Redis engine version on AWS ElastiCache in version 3.4.2, which means we should still either:
* set keys using `HKEY` one at the time
* use `HMKEY` to set up multiple keys at the time

<img width="374" alt="image" src="https://user-images.githubusercontent.com/338769/126990374-0b6bd28a-1084-4f46-b477-8d4039e258e6.png">


This PR brings this change back: https://github.com/splitrb/split/commit/cc7c41bfc72774c59068fe86a1684fc3db0cee23

Otherwise, we get an error as below:

```
ERR wrong number of arguments for 'hset' command (Redis::CommandError)
Redis::CommandError:
ERR wrong number of arguments for 'hset' command
```